### PR TITLE
Will now show context menu below button (similar to how dropdowns work)

### DIFF
--- a/Assets/Textus/SerializeReferenceUI/Core/SerializeReferenceGenericSelectionMenu.cs
+++ b/Assets/Textus/SerializeReferenceUI/Core/SerializeReferenceGenericSelectionMenu.cs
@@ -9,18 +9,32 @@ using UnityEngine;
 public static class SerializeReferenceGenericSelectionMenu
 {
     /// Purpose.
-    /// This is generic selection menu.   
+    /// This is generic selection menu (will appear at position).
     /// Filtering. 
     /// You can add substring filter here to filter by search string.
     /// As well ass type or interface restrictions.
     /// As well as any custom restriction that is based on input type.
     /// And it will be performed on each Appropriate type found by TypeCache.
-    public static void ShowContextMenuForManagedReference(this SerializedProperty property, IEnumerable<Func<Type,bool>> filters = null)
+    public static void ShowContextMenuForManagedReference(this SerializedProperty property, Rect position, IEnumerable<Func<Type,bool>> filters = null)
     { 
         var context = new GenericMenu();
         FillContextMenu(filters, context, property);
+        context.DropDown(position);
+    }
+
+    /// Purpose.
+    /// This is generic selection menu (will appear at click position).
+    /// Filtering. 
+    /// You can add substring filter here to filter by search string.
+    /// As well ass type or interface restrictions.
+    /// As well as any custom restriction that is based on input type.
+    /// And it will be performed on each Appropriate type found by TypeCache.
+    public static void ShowContextMenuForManagedReference(this SerializedProperty property, IEnumerable<Func<Type, bool>> filters = null)
+    {
+        var context = new GenericMenu();
+        FillContextMenu(filters, context, property);
         context.ShowAsContext();
-    }  
+    }
     
     private static void FillContextMenu(IEnumerable<Func<Type, bool>> enumerableFilters, GenericMenu contextMenu, SerializedProperty property)
     {

--- a/Assets/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorButton.cs
+++ b/Assets/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorButton.cs
@@ -35,7 +35,7 @@ public static class SerializeReferenceInspectorButton
         var className = string.IsNullOrEmpty(names.ClassName) ? "Null (Assign)" : names.ClassName;
         var assemblyName = names.AssemblyName;
         if (GUI.Button(buttonPosition, new GUIContent(className, className + "  ( "+ assemblyName +" )" )))
-            property.ShowContextMenuForManagedReference(filters);
+            property.ShowContextMenuForManagedReference(buttonPosition, filters);
         
         GUI.backgroundColor = storedColor;
         EditorGUI.indentLevel = storedIndent;


### PR DESCRIPTION
Quality of life change, it was a bit frustrating that the "dropdown"-menu appeared at different places every click (because mouse moved), now it will appear below the label/button instead.